### PR TITLE
Support for unary operators

### DIFF
--- a/easymoney.py
+++ b/easymoney.py
@@ -24,7 +24,7 @@ def _to_decimal(amount):
         return Decimal(amount)
 
 
-def _make_method(name):
+def _make_binary_operator(name):
     method = getattr(Decimal, name, None)
 
     def __money_method__(self, other, context=None):
@@ -143,24 +143,24 @@ class Money(Decimal):
         else:
             return False
 
-    __add__ = _make_method('__add__')
-    __radd__ = _make_method('__radd__')
-    __sub__ = _make_method('__sub__')
-    __rsub__ = _make_method('__rsub__')
-    __mul__ = _make_method('__mul__')
-    __rmul__ = _make_method('__rmul__')
-    __floordiv__ = _make_method('__floordiv__')
-    __rfloordiv__ = _make_method('__rfloordiv__')
-    __truediv__ = _make_method('__truediv__')
-    __rtruediv__ = _make_method('__rtruediv__')
-    __div__ = _make_method('__div__')
-    __rdiv__ = _make_method('__rdiv__')
-    __mod__ = _make_method('__mod__')
-    __rmod__ = _make_method('__rmod__')
-    __divmod__ = _make_method('__divmod__')
-    __rdivmod__ = _make_method('__rdivmod__')
-    __pow__ = _make_method('__pow__')
-    __rpow__ = _make_method('__rpow__')
+    __add__ = _make_binary_operator('__add__')
+    __radd__ = _make_binary_operator('__radd__')
+    __sub__ = _make_binary_operator('__sub__')
+    __rsub__ = _make_binary_operator('__rsub__')
+    __mul__ = _make_binary_operator('__mul__')
+    __rmul__ = _make_binary_operator('__rmul__')
+    __floordiv__ = _make_binary_operator('__floordiv__')
+    __rfloordiv__ = _make_binary_operator('__rfloordiv__')
+    __truediv__ = _make_binary_operator('__truediv__')
+    __rtruediv__ = _make_binary_operator('__rtruediv__')
+    __div__ = _make_binary_operator('__div__')
+    __rdiv__ = _make_binary_operator('__rdiv__')
+    __mod__ = _make_binary_operator('__mod__')
+    __rmod__ = _make_binary_operator('__rmod__')
+    __divmod__ = _make_binary_operator('__divmod__')
+    __rdivmod__ = _make_binary_operator('__rdivmod__')
+    __pow__ = _make_binary_operator('__pow__')
+    __rpow__ = _make_binary_operator('__rpow__')
 
 
 # Model field

--- a/easymoney.py
+++ b/easymoney.py
@@ -24,6 +24,19 @@ def _to_decimal(amount):
         return Decimal(amount)
 
 
+def _make_unary_operator(name):
+    method = getattr(Decimal, name, None)
+
+    def __money_method__(self, context=None):
+        if method is None:
+            raise NotImplementedError(
+                'Decimal.{name} is not implemented.'.format(name=name))
+        args = (context,) if context is not None else ()
+        return self.__class__(method(self, *args))
+
+    return __money_method__
+
+
 def _make_binary_operator(name):
     method = getattr(Decimal, name, None)
 
@@ -142,6 +155,10 @@ class Money(Decimal):
             return Decimal.__eq__(self, self._sanitize(other))
         else:
             return False
+
+    __abs__ = _make_unary_operator('__abs__')
+    __pos__ = _make_unary_operator('__pos__')
+    __neg__ = _make_unary_operator('__neg__')
 
     __add__ = _make_binary_operator('__add__')
     __radd__ = _make_binary_operator('__radd__')

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import copy
 import pickle
 from decimal import Decimal
+from operator import floordiv
+from operator import truediv
 
 from mock import patch
 
@@ -82,6 +84,9 @@ def test_arithmetic_returns_money_instance():
     assert type(truediv(3, Money(2))) is Money
     assert type(Money(3) ** 2) is Money
     assert type(2 ** Money(3)) is Money
+    assert type(+Money(2)) is Money
+    assert type(-Money(2)) is Money
+    assert type(abs(Money(2))) is Money
 
 
 def test_precision():

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -63,6 +63,11 @@ def test_arithmetic():
     assert pi + e == 5.92
     assert pi - e == 0.36
 
+    assert -pi == -3.14
+    assert +pi == 3.14
+    assert abs(pi) == 3.14
+    assert abs(-pi) == 3.14
+
 
 def test_precision():
     assert Money(1000) * 1.001 == 1001

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -69,6 +69,21 @@ def test_arithmetic():
     assert abs(-pi) == 3.14
 
 
+def test_arithmetic_returns_money_instance():
+    assert type(Money(3) + 2) is Money
+    assert type(3 + Money(2)) is Money
+    assert type(Money(3) - 2) is Money
+    assert type(3 - Money(2)) is Money
+    assert type(Money(3) * 2) is Money
+    assert type(3 * Money(2)) is Money
+    assert type(floordiv(Money(3), 2)) is Money
+    assert type(floordiv(3, Money(2))) is Money
+    assert type(truediv(Money(3), 2)) is Money
+    assert type(truediv(3, Money(2))) is Money
+    assert type(Money(3) ** 2) is Money
+    assert type(2 ** Money(3)) is Money
+
+
 def test_precision():
     assert Money(1000) * 1.001 == 1001
     assert Money('1.001') * 1000 == 1000


### PR DESCRIPTION
easymoney supports arithmetic operations with other types that convert to decimals. The binary operators (like add, devision, etc) all return new Money instances, instead of Decimal instances.

It would make sense to introduce the same behaviour for unary operators, like negation.

This pull request supports these and adds tests for it.

(We had this usecase in oTree and added the unary methods there downstream: https://github.com/oTree-org/otree-core/blob/419d80322a9c30b3296bfe7c972e6a08d8af6089/otree/common.py)
