### PR TITLE
Make sure Money.__repr__ does not return bytes in Python 3

### DIFF
--- a/easymoney.py
+++ b/easymoney.py
@@ -133,7 +133,12 @@ class Money(Decimal):
             return formatted
 
     def __repr__(self):
-        return stdout_encode(u'Money(%s)' % self)
+        repr_str = u'Money(%s)' % self
+        # __repr__ always returns a string type. We don't want to return bytes
+        # in PY3.
+        if six.PY2:
+            return stdout_encode(repr_str)
+        return repr_str
 
     def __eq__(self, other):
         if isinstance(other, Money):

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -37,6 +37,11 @@ def test_str():
         assert str(Money(3)) == '3.00 points'
 
 
+def test_repr():
+    pi = Money('3.14')
+    assert repr(pi) == 'Money($3.14)'
+
+
 def test_format():
     pi = Money(3.14)
     assert '{}'.format(pi) == '$3.14'


### PR DESCRIPTION
`stdout_encode` returns an encoded string, which is `str` in Python 2 (and therefore applicable as return value for `__repr__`), but returns `bytes` in Python 3. However Python 3 expects a `str` as return value for `__repr__`.

I added a simple test case and a fix for it.

This fixes #4.
