### PR TITLE
Define __hash__ method because we defined an __eq__ method

### DIFF
--- a/easymoney.py
+++ b/easymoney.py
@@ -146,6 +146,11 @@ class Money(Decimal):
         else:
             return False
 
+    # for Python 3:
+    # need to re-define __hash__ because we defined __eq__ above
+    # https://docs.python.org/3.5/reference/datamodel.html#object.%5F%5Fhash%5F%5F
+    __hash__ = Decimal.__hash__
+
     # Special casing this, cause it have extra modulo arg
     def __pow__(self, other, modulo=None):
         return self.__class__(Decimal.__pow__(self, _to_decimal(other), modulo))


### PR DESCRIPTION
Python 3 requires this: https://docs.python.org/3.5/reference/datamodel.html#object.%5F%5Fhash%5F%5F
Otherwise, I get "unhashable data type" exception if I use a Money amount as a key in a dict
